### PR TITLE
Dyanmic Top Sellers w/ Loading State

### DIFF
--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -6,8 +6,6 @@ import axios from "axios";
 import "owl.carousel/dist/assets/owl.carousel.css";
 import "owl.carousel/dist/assets/owl.theme.default.css";
 import OwlCarousel from "react-owl-carousel";
-import Skeleton from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
 
 const HotCollections = () => {
   const [collections, setCollections] = useState([]);
@@ -59,11 +57,23 @@ const HotCollections = () => {
 
           {loading ? (
             new Array(4).fill(0).map((_, i) => (
-              <div key={i} className="p-4">
-                <div className="animate-pulse rounded-xl bg-gray-300 h-64 w-full" />
-                <div className="mt-3 space-y-2">
-                  <div className="h-4 bg-gray-300 rounded w-2/3"></div>
-                  <div className="h-3 bg-gray-300 rounded w-1/3"></div>
+              <div key={i} className="col-md-3 mb-4">
+                <div className="card placeholder-glow">
+                  <div
+                    className="card-img-top placeholder"
+                    style={{ height: "200px" }}
+                  ></div>
+                  <div className="card-body text-center">
+                    <div className="mb-2">
+                      <span className="placeholder rounded-circle col-4"></span>
+                    </div>
+                    <h5 className="card-title">
+                      <span className="placeholder col-6"></span>
+                    </h5>
+                    <p className="card-text">
+                      <span className="placeholder col-4"></span>
+                    </p>
+                  </div>
                 </div>
               </div>
             ))

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -92,11 +92,20 @@ const NewItems = () => {
           </div>
           {loading ? (
             new Array(4).fill(0).map((_, index) => (
-              <div key={index} className="p-4">
-                <div className="animate-pulse rounded-xl bg-gray-300 h-64 w-full" />
-                <div className="mt-3 space-y-2">
-                  <div className="h-4 bg-gray-300 rounded w-2/3"></div>
-                  <div className="h-3 bg-gray-300 rounded w-1/3"></div>
+              <div key={index} className="col-md-3 mb-4">
+                <div className="card placeholder-glow">
+                  <div
+                    className="card-img-top placeholder"
+                    style={{ height: "200px" }}
+                  ></div>
+                  <div className="card-body">
+                    <h5 className="card-title">
+                      <span className="placeholder col-6"></span>
+                    </h5>
+                    <p className="card-text">
+                      <span className="placeholder col-4"></span>
+                    </p>
+                  </div>
                 </div>
               </div>
             ))

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -1,8 +1,28 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import AuthorImage from "../../images/author_thumbnail.jpg";
+import axios from "axios";
 
 const TopSellers = () => {
+  const [sellers, setSellers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSellers = async () => {
+      try {
+        const { data } = await axios.get(
+          `https://us-central1-nft-cloud-functions.cloudfunctions.net/topSellers`
+        );
+        setSellers(data);
+      } catch (err) {
+        console.error("Error fetching Top Sellers", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchSellers();
+  }, []);
+
   return (
     <section id="section-popular" className="pb-5">
       <div className="container">
@@ -15,24 +35,38 @@ const TopSellers = () => {
           </div>
           <div className="col-md-12">
             <ol className="author_list">
-              {new Array(12).fill(0).map((_, index) => (
-                <li key={index}>
-                  <div className="author_list_pp">
-                    <Link to="/author">
-                      <img
-                        className="lazy pp-author"
-                        src={AuthorImage}
-                        alt=""
-                      />
-                      <i className="fa fa-check"></i>
-                    </Link>
-                  </div>
-                  <div className="author_list_info">
-                    <Link to="/author">Monica Lucas</Link>
-                    <span>2.1 ETH</span>
-                  </div>
-                </li>
-              ))}
+              {loading
+                ? new Array(12).fill(0).map((_, index) => (
+                     <li key={index} className="d-flex align-items-center mb-3">
+                      <div className="author_list_pp me-3">
+                        <span className="placeholder rounded-circle" style={{ width: "50px", height: "50px" }}></span>
+                      </div>
+                      <div className="author_list_info w-100">
+                        <span className="placeholder col-6 d-block mb-2"></span>
+                        <span className="placeholder col-3 d-block"></span>
+                      </div>
+                    </li>
+                  ))
+                : sellers.map((sellers, index) => (
+                    <li key={sellers.id || index}>
+                      <div className="author_list_pp">
+                        <Link to={`/author/${sellers.authorId}`}>
+                          <img
+                            className="lazy pp-author"
+                            src={sellers.authorImage}
+                            alt=""
+                          />
+                          <i className="fa fa-check"></i>
+                        </Link>
+                      </div>
+                      <div className="author_list_info">
+                        <Link to={`/author/${sellers.authorId}`}>
+                          {sellers.authorName}
+                        </Link>
+                        <span>{sellers.price} ETH</span>
+                      </div>
+                    </li>
+                  ))}
             </ol>
           </div>
         </div>


### PR DESCRIPTION
TASK:
1) Map over Top Sellers data with API data and route each other image and name to authors' ID page.
2) Add Skeleton Loading State over Sellers Cards
HOW:
1) Created a useState for the sellers and a useEffect for fetching the sellers information from the API with an error in case it messes up.
2) Created a skeleton loading loading state through a new array with 12 items for the 12 top sellers. Mimicked the layout of the cards while adding the css style for the gray loading state boxes. I made sure it was similar to the Hot Collections and New Items sections.
WHY:
1) So anyone looking for the top sellers can see the 12 top sellers and if they want to click in the individual seller they will be routed to the sellers' specific page.
2) I looked deeper into the skeleton states I was designing and realized I had the right idea with what I was building but was using the wrong CSS style. I was using Tailwind CSS instead of Bootstrap. I created the correct loading state for the Top Sellers list using Bootstrap styling. After realizing my mistake I went back and adjusted the the CSS for Hot Collections & New Items so they all matched. Gray boxes with pulse for loading state.

<img width="1441" height="381" alt="Top Sellers Loading State" src="https://github.com/user-attachments/assets/5931aacc-fbee-4c3d-afc3-771366d0d8b4" />
<img width="1422" height="424" alt="Top Sellers w: API data" src="https://github.com/user-attachments/assets/004a7369-e02d-44ed-a1ad-b18e2839619c" />
