### PR TITLE
Dynamic Item Details with Loading State

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/explore" element={<Explore />} />
         <Route path="/author/:id" element={<Author />} />
-        <Route path="/item-details" element={<ItemDetails />} />
+        <Route path="/item-details/:id" element={<ItemDetails />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/components/author/AuthorItems.jsx
+++ b/src/components/author/AuthorItems.jsx
@@ -87,7 +87,7 @@ const AuthorItems = () => {
                           </div>
                         </div>
                       </div>
-                      <Link to="/item-details">
+                      <Link to={`/item-details/${item.nftId}`}>
                         <img
                           src={item.nftImage}
                           className="lazy nft__item_preview"

--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -83,7 +83,7 @@ const HotCollections = () => {
                 <div className="gap-4" key={item.id || index}>
                   <div className="nft_coll">
                     <div className="nft_wrap">
-                      <Link to={`/item-details/${item.id}`}>
+                      <Link to={`/item-details/${item.nftId}`}>
                         <img
                           src={item.nftImage}
                           className="lazy img-fluid"

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -1,10 +1,31 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import EthImage from "../images/ethereum.svg";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import AuthorImage from "../images/author_thumbnail.jpg";
 import nftImage from "../images/nftImage.jpg";
+import axios from "axios";
 
 const ItemDetails = () => {
+  const { id } = useParams();
+  const [details, setDetails] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchDetails = async () => {
+      try {
+        const { data } = await axios.get(
+          `https://us-central1-nft-cloud-functions.cloudfunctions.net/itemDetails?nftId=${id}`
+        );
+        setDetails(data);
+      } catch (err) {
+        console.error("Error fetching Item Details", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchDetails();
+  }, [id]);
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
@@ -16,73 +37,123 @@ const ItemDetails = () => {
         <section aria-label="section" className="mt90 sm-mt-0">
           <div className="container">
             <div className="row">
-              <div className="col-md-6 text-center">
-                <img
-                  src={nftImage}
-                  className="img-fluid img-rounded mb-sm-30 nft-image"
-                  alt=""
-                />
-              </div>
-              <div className="col-md-6">
-                <div className="item_info">
-                  <h2>Rainbow Style #194</h2>
+              {loading ? (
+                new Array(1).fill(0).map((_, index) => (
+                  <div key={index} className="d-flex">
+                    <div
+                      className="item-img placeholder"
+                      style={{ height: "400px", width: "100%", borderRadius: "12px" }}
+                    ></div>
 
-                  <div className="item_info_counts">
-                    <div className="item_info_views">
-                      <i className="fa fa-eye"></i>
-                      100
-                    </div>
-                    <div className="item_info_like">
-                      <i className="fa fa-heart"></i>
-                      74
-                    </div>
-                  </div>
-                  <p>
-                    doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
-                    illo inventore veritatis et quasi architecto beatae vitae
-                    dicta sunt explicabo.
-                  </p>
-                  <div className="d-flex flex-row">
-                    <div className="mr40">
-                      <h6>Owner</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
+                    <div className="item-body col-md-6">
+                      <div className="placeholder-glow">
+                        <h2 className="item-title">
+                          <span className="placeholder" style={{ height: "50px", width: "300px" }}></span>
+                        </h2>
+                        <div className="d-flex mb-3">
+                          <span className="placeholder col-2 me-3"></span>
+                          <span className="placeholder col-2"></span>
                         </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                        <p className="item-description">
+                          <span className="placeholder col-12"></span>
+                          <span className="placeholder col-10"></span>
+                          <span className="placeholder col-6"></span>
+                        </p>
+                        <div className="d-flex flex-row align-items-center mb-3">
+                          <div className="placeholder" style={{ height: "50px", width: "50px", borderRadius: "50%" }}></div>
+                          <div className="ms-3">
+                            <span className="placeholder col-6"></span>
+                          </div>
+                        </div>
+                        <div className="d-flex flex-row align-items-center">
+                          <div className="placeholder" style={{ height: "50px", width: "50px", borderRadius: "50%" }}></div>
+                          <div className="ms-3">
+                            <span className="placeholder col-6"></span>
+                          </div>
                         </div>
                       </div>
                     </div>
-                    <div></div>
                   </div>
-                  <div className="de_tab tab_simple">
-                    <div className="de_tab_content">
-                      <h6>Creator</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
+                ))
+              ) : (
+                <>
+                  <div className="col-md-6 text-center">
+                    <img
+                      src={details.nftImage}
+                      className="img-fluid img-rounded mb-sm-30 nft-image"
+                      alt=""
+                    />
+                  </div>
+                  <div className="col-md-6">
+                    <div className="item_info">
+                      <h2>{details.title}</h2>
+
+                      <div className="item_info_counts">
+                        <div className="item_info_views">
+                          <i className="fa fa-eye"></i>
+                          {details.views}
                         </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                        <div className="item_info_like">
+                          <i className="fa fa-heart"></i>
+                          {details.likes}
+                        </div>
+                      </div>
+                      <p>{details.description}</p>
+                      <div className="d-flex flex-row">
+                        <div className="mr40">
+                          <h6>Owner</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to={`/author/${details.ownerId}`}>
+                                <img
+                                  className="lazy"
+                                  src={details.ownerImage}
+                                  alt=""
+                                />
+                                <i className="fa fa-check"></i>
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to={`/author/${details.ownerId}`}>
+                                {details.ownerName}
+                              </Link>
+                            </div>
+                          </div>
+                        </div>
+                        <div></div>
+                      </div>
+                      <div className="de_tab tab_simple">
+                        <div className="de_tab_content">
+                          <h6>Creator</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to={`/author/${details.creatorId}`}>
+                                <img
+                                  className="lazy"
+                                  src={details.creatorImage}
+                                  alt=""
+                                />
+                                <i className="fa fa-check"></i>
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to={`/author/${details.creatorId}`}>
+                                {details.creatorName}
+                              </Link>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="spacer-40"></div>
+                        <h6>Price</h6>
+                        <div className="nft-item-price">
+                          <img src={EthImage} alt="" />
+                          <span>{details.price}</span>
                         </div>
                       </div>
                     </div>
-                    <div className="spacer-40"></div>
-                    <h6>Price</h6>
-                    <div className="nft-item-price">
-                      <img src={EthImage} alt="" />
-                      <span>1.85</span>
-                    </div>
                   </div>
-                </div>
-              </div>
+                </>
+              )}
             </div>
           </div>
         </section>


### PR DESCRIPTION
TASK:
1) Map over Item Details page with Item API with proper routing.
2) Add a loading state over the page.
HOW:
1) I used the same function I had created with the Author page by creating a useParams with the ID and a useState variable based on the details of the specific NFT item we are looking. The API is pulling data based off the id again as well. I also double-checked my other pages to make sure all my routing to the item detail page was correct, "<Link to={`/item-details/${item.nftID}`}>". I also modified the App.jsx page again to get the route to the item-details page to work correctly and not to a blank page, "<Route path "/item-details/:id"...".
2) I used the same style of loading state I have been using for the rest of the site. This one with a little more detail to compensate for all the various components of the site from the NFT Image, Owner & Creator name and picture, and the item name and description.
WHY:
1) I had already created the same function for the Author page and was able to reuse it for the item-details page since it was just mapping over one item from the API. So created the same type of function and then made the details on the page dynamic. It keeps my part of the code similar across all parts of the page instead of changing it for every page I work on or edit.
2) I reused the same layout so all the loading states look cohesive. I spent more time adding the different sections of so when the pages does load from the loading state it isn't jumping around and adding item details where the loading state wasn't. I wanted the loading states to match all over the website and within my code so it's easier to work with and write I kept working.

<img width="1389" height="573" alt="Item Details Loading State" src="https://github.com/user-attachments/assets/85101317-51c4-454e-bd23-892e9b1149af" />
<img width="1380" height="747" alt="Item Details w: API Data" src="https://github.com/user-attachments/assets/c2a3cb17-9418-46fe-b19c-534f6bb7d11d" />
